### PR TITLE
Replace log with logrus

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"strconv"
 	"strings"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"strconv"


### PR DESCRIPTION
Namespace(repository='github.com/sourcegraph-ce/terraform-provider-dns', batch_change_name='log-provider-go-with-python-script', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script)